### PR TITLE
feat(hex): use alloc version of hex by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 blake2 = { version = "0.10.4", default-features = false }
+hex = { version = "0.4", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 sha3 = { version = "0.10.1", default-features = false }
 thiserror = "1.0"
-hex = "0.4"
 
 [features]
 default = [ "std" ]
@@ -16,4 +16,5 @@ std = [
   "blake2/std",
   "rand/std",
   "sha3/std",
+  "hex/std"
 ]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -7,6 +7,7 @@ use rand::{rngs::OsRng, RngCore};
 /// Size of WOTS+ public keys
 pub const PK_SIZE: usize = 32;
 
+#[derive(Clone)]
 pub struct Key<PRFH: Hasher + Clone, MSGH: Hasher + Clone> {
     pub p_seed: [u8; SEED_SIZE],
     pub chains: Option<Vec<Vec<u8>>>,


### PR DESCRIPTION
## Changes

- configure `default-features = false` for hex

## Tests

```
cargo b --no-default-features
```

## Issues

-