### PR TITLE
update default params to have generic hashers

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -363,7 +363,7 @@ fn parity(value: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::hasher::{Blake2bHasher, Hasher};
+    use crate::hasher::{Blake2bHasher, Hasher, Sha3_256Hasher};
     use crate::params::{ComputeLaddersMode, Params, MAX_MSG_SIZE, SEED_SIZE, W};
     use crate::security;
     use crate::security::ParamsEncoding;
@@ -396,8 +396,7 @@ mod tests {
 
     #[test]
     fn compute_chain() {
-        let params = security::consensus_params();
-
+        let params = security::consensus_params::<Blake2bHasher, Sha3_256Hasher>();
         let total = 16; //arbitrary
         let input = vec![99u8; 32];
         let p_seed = vec![88u8; SEED_SIZE];

--- a/src/security.rs
+++ b/src/security.rs
@@ -205,11 +205,6 @@ mod tests {
         let msg = vec![99u8; MAX_MSG_SIZE];
         let res = key.sign(&msg).unwrap();
         assert_eq!(res.len(), sig_size);
-
-        println!("{:?}", hex::encode(&msg));
-        println!("{:?}", hex::encode(&res));
-        println!("{:?}", hex::encode(&key.public_key));
-
         verify(&msg, &res, &key.public_key).unwrap();
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -42,12 +42,8 @@ impl From<&ParamsEncoding> for u8 {
 impl<PRFH: Hasher + Clone, MSGH: Hasher + Clone> From<&ParamsEncoding> for Params<PRFH, MSGH> {
     fn from(item: &ParamsEncoding) -> Self {
         match item {
-            ParamsEncoding::Level0 => level_0_params(),
-            ParamsEncoding::Level1 => level_1_params(),
-            ParamsEncoding::Level2 => level_2_params(),
-            ParamsEncoding::Level3 => level_3_params(),
-            ParamsEncoding::Consensus => consensus_params(),
             ParamsEncoding::Custom => consensus_params(), // TODO
+            _ => Params::new(item.clone()).expect("instantiating level0 params should not fail"),
         }
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,6 +1,6 @@
 use std::convert::From;
 
-use crate::hasher::{Blake2bHasher, Sha3_224Hasher, Sha3_256Hasher};
+use crate::hasher::{Blake2bHasher, Hasher, Sha3_224Hasher, Sha3_256Hasher};
 use crate::params::{Params, WotsError};
 
 #[derive(Debug, Clone)]
@@ -39,38 +39,66 @@ impl From<&ParamsEncoding> for u8 {
     }
 }
 
-pub fn level_0_params() -> Params<Blake2bHasher, Sha3_224Hasher> {
-    Params::<Blake2bHasher, Sha3_224Hasher>::new(ParamsEncoding::Level0)
-        .expect("instantiating level0 params should not fail")
+impl<PRFH: Hasher + Clone, MSGH: Hasher + Clone> From<&ParamsEncoding> for Params<PRFH, MSGH> {
+    fn from(item: &ParamsEncoding) -> Self {
+        match item {
+            ParamsEncoding::Level0 => level_0_params(),
+            ParamsEncoding::Level1 => level_1_params(),
+            ParamsEncoding::Level2 => level_2_params(),
+            ParamsEncoding::Level3 => level_3_params(),
+            ParamsEncoding::Consensus => consensus_params(),
+            ParamsEncoding::Custom => consensus_params(), // TODO
+        }
+    }
 }
 
-pub fn level_1_params() -> Params<Blake2bHasher, Sha3_224Hasher> {
-    Params::<Blake2bHasher, Sha3_224Hasher>::new(ParamsEncoding::Level1)
-        .expect("instantiating level1 params should not fail")
+pub fn level_0_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<PRFH, MSGH> {
+    Params::new(ParamsEncoding::Level0).expect("instantiating level0 params should not fail")
 }
 
-pub fn level_2_params() -> Params<Blake2bHasher, Sha3_224Hasher> {
-    Params::<Blake2bHasher, Sha3_224Hasher>::new(ParamsEncoding::Level2)
-        .expect("instantiating level2 params should not fail")
+pub fn level_1_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<PRFH, MSGH> {
+    Params::new(ParamsEncoding::Level1).expect("instantiating level1 params should not fail")
 }
 
-pub fn level_3_params() -> Params<Blake2bHasher, Sha3_224Hasher> {
-    Params::<Blake2bHasher, Sha3_224Hasher>::new(ParamsEncoding::Level3)
-        .expect("instantiating level3 params should not fail")
+pub fn level_2_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<PRFH, MSGH> {
+    Params::new(ParamsEncoding::Level2).expect("instantiating level2 params should not fail")
 }
 
-pub fn consensus_params() -> Params<Blake2bHasher, Sha3_256Hasher> {
-    Params::<Blake2bHasher, Sha3_256Hasher>::new(ParamsEncoding::Consensus)
-        .expect("instantiating consensus params should not fail")
+pub fn level_3_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<PRFH, MSGH> {
+    Params::new(ParamsEncoding::Level3).expect("instantiating level3 params should not fail")
+}
+
+pub fn consensus_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<PRFH, MSGH> {
+    Params::new(ParamsEncoding::Consensus).expect("instantiating consensus params should not fail")
 }
 
 pub fn verify(msg: &[u8], signature: &[u8], public_key: &[u8]) -> Result<(), WotsError> {
     match ParamsEncoding::from(signature[0]) {
-        ParamsEncoding::Level0 => level_0_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level1 => level_1_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level2 => level_2_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level3 => level_3_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Consensus => consensus_params().verify(msg, &signature[1..], public_key),
+        ParamsEncoding::Level0 => level_0_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level1 => level_1_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level2 => level_2_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level3 => level_3_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Consensus => consensus_params::<Blake2bHasher, Sha3_256Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
         _ => Err(WotsError::InvalidParamsEncodingType),
     }
 }
@@ -82,10 +110,26 @@ pub fn verify_no_consensus(
     public_key: &[u8],
 ) -> Result<(), WotsError> {
     match ParamsEncoding::from(signature[0]) {
-        ParamsEncoding::Level0 => level_0_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level1 => level_1_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level2 => level_2_params().verify(msg, &signature[1..], public_key),
-        ParamsEncoding::Level3 => level_3_params().verify(msg, &signature[1..], public_key),
+        ParamsEncoding::Level0 => level_0_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level1 => level_1_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level2 => level_2_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
+        ParamsEncoding::Level3 => level_3_params::<Blake2bHasher, Sha3_224Hasher>().verify(
+            msg,
+            &signature[1..],
+            public_key,
+        ),
         _ => Err(WotsError::InvalidParamsEncodingType),
     }
 }
@@ -100,30 +144,30 @@ mod tests {
 
     #[test]
     fn params_test() {
-        let params = security::level_0_params();
+        let params = security::level_0_params::<Blake2bHasher, Sha3_224Hasher>();
         assert_eq!(params.n, 20);
         assert_eq!(params.m, 24);
 
-        let params = security::level_1_params();
+        let params = security::level_1_params::<Blake2bHasher, Sha3_224Hasher>();
         assert_eq!(params.n, 24);
         assert_eq!(params.m, 24);
 
-        let params = security::level_2_params();
+        let params = security::level_2_params::<Blake2bHasher, Sha3_224Hasher>();
         assert_eq!(params.n, 28);
         assert_eq!(params.m, 24);
 
-        let params = security::level_3_params();
+        let params = security::level_3_params::<Blake2bHasher, Sha3_224Hasher>();
         assert_eq!(params.n, 32);
         assert_eq!(params.m, 24);
 
-        let params = security::consensus_params();
+        let params = security::consensus_params::<Blake2bHasher, Sha3_256Hasher>();
         assert_eq!(params.n, 32);
         assert_eq!(params.m, 32);
     }
 
     #[test]
     fn verify_consensus_params_should_fail() {
-        let params = security::consensus_params();
+        let params = security::consensus_params::<Blake2bHasher, Sha3_256Hasher>();
         let sig_size = (params.n * params.total) + 1 + SEED_SIZE;
         let mut key = Key::<Blake2bHasher, Sha3_256Hasher>::new(params).unwrap();
         key.generate().unwrap();
@@ -153,14 +197,18 @@ mod tests {
 
     #[test]
     fn verify_test_generate() {
-        let params = security::level_3_params();
+        let params = security::consensus_params();
         let sig_size = (params.n * params.total) + 1 + SEED_SIZE;
-        let mut key = Key::<Blake2bHasher, Sha3_224Hasher>::new(params).unwrap();
+        let mut key = Key::<Blake2bHasher, Sha3_256Hasher>::new(params).unwrap();
         key.generate().unwrap();
 
         let msg = vec![99u8; MAX_MSG_SIZE];
         let res = key.sign(&msg).unwrap();
         assert_eq!(res.len(), sig_size);
+
+        println!("{:?}", hex::encode(&msg));
+        println!("{:?}", hex::encode(&res));
+        println!("{:?}", hex::encode(&key.public_key));
 
         verify(&msg, &res, &key.public_key).unwrap();
     }

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -203,7 +203,12 @@ mod tests {
         seed.copy_from_slice(&secret_seed);
         let mut p_seed = [0u8; 32];
         p_seed.copy_from_slice(&public_seed);
-        let key = Key::from_seed(security::level_0_params(), seed, p_seed).unwrap();
+        let key = Key::<Blake2bHasher, Sha3_224Hasher>::from_seed(
+            security::level_0_params(),
+            seed,
+            p_seed,
+        )
+        .unwrap();
         assert_eq!(key.secret_key, expected_secret_key);
         assert_eq!(key.public_key, expected_public_key);
     }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update default params to be generic enabling `impl<PRFH: Hasher + Clone, MSGH: Hasher + Clone> From<&ParamsEncoding> for Params<PRFH, MSGH>`
- if there's a better way to do this let me know

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo test
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-