### PR TITLE
Fix panic when verifying an empty signature. Add test case

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -46,7 +46,7 @@ pub enum WotsError {
     ExpectedMessage,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ComputeLaddersMode {
     Generate,
     Sign,

--- a/src/security.rs
+++ b/src/security.rs
@@ -69,8 +69,8 @@ pub fn consensus_params<PRFH: Hasher + Clone, MSGH: Hasher + Clone>() -> Params<
 }
 
 pub fn verify(msg: &[u8], signature: &[u8], public_key: &[u8]) -> Result<(), WotsError> {
-    if signature.len() == 0 {
-        return Err(WotsError::InvalidSignatureSize)
+    if signature.is_empty() {
+        return Err(WotsError::InvalidSignatureSize);
     }
     match ParamsEncoding::from(signature[0]) {
         ParamsEncoding::Level0 => level_0_params::<Blake2bHasher, Sha3_224Hasher>().verify(
@@ -108,8 +108,8 @@ pub fn verify_no_consensus(
     signature: &[u8],
     public_key: &[u8],
 ) -> Result<(), WotsError> {
-    if signature.len() == 0 {
-        return Err(WotsError::InvalidSignatureSize)
+    if signature.is_empty() {
+        return Err(WotsError::InvalidSignatureSize);
     }
     match ParamsEncoding::from(signature[0]) {
         ParamsEncoding::Level0 => level_0_params::<Blake2bHasher, Sha3_224Hasher>().verify(


### PR DESCRIPTION
## Changes

Added a check for empty signature to `verify` and `verify_no_consensus`.
Both functions were panicking due to accessing byte 0 of the signature to determine the params to use.

## Tests

Added a test case that verifies an empty signature.
